### PR TITLE
Add semantic versioning configuration and initialize version

### DIFF
--- a/.sdlc/git-semantic-versioning.yaml
+++ b/.sdlc/git-semantic-versioning.yaml
@@ -1,0 +1,35 @@
+- uses: paulhatch/semantic-version@v5.4.0
+  with:
+    # The prefix to use to identify tags
+    tag_prefix: "v"
+    # A string which, if present in a git commit, indicates that a change represents a
+    # major (breaking) change, supports regular expressions wrapped with '/'
+    major_pattern: "(MAJOR)"
+    # A string which indicates the flags used by the `major_pattern` regular expression. Supported flags: idgs
+    major_regexp_flags: ""
+    # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
+    minor_pattern: "(MINOR)"
+    # A string which indicates the flags used by the `minor_pattern` regular expression. Supported flags: idgs
+    minor_regexp_flags: ""
+    # A string to determine the format of the version output
+    version_format: "${major}.${minor}.${patch}-prerelease${increment}"
+    # Optional path to check for changes. If any changes are detected in the path the
+    # 'changed' output will true. Enter multiple paths separated by spaces.
+    change_path: "src/"
+    # Named version, will be used as suffix for name version tag
+    namespace: dogs-api-tests-pet-project
+    # If this is set to true, *every* commit will be treated as a new version.
+    bump_each_commit: false
+    # If bump_each_commit is also set to true, setting this value will cause the version to increment only if the pattern specified is matched.
+    bump_each_commit_patch_pattern: ""
+    # If true, the body of commits will also be searched for major/minor patterns to determine the version type.
+    search_commit_body: false
+    # The output method used to generate list of users, 'csv' or 'json'.
+    user_format_type: "csv"
+    # Prevents pre-v1.0.0 version from automatically incrementing the major version.
+    # If enabled, when the major version is 0, major releases will be treated as minor and minor as patch. Note that the version_type output is unchanged.
+    enable_prerelease_mode: true
+    # If enabled, diagnostic information will be added to the action output.
+    debug: false
+    # If true, the branch will be used to select the maximum version.
+    version_from_branch: false

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.truenvy</groupId>
     <artifactId>dogs-api-api-tests</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Introduce a semantic versioning workflow using `paulhatch/semantic-version@v5.4.0` to manage versioning based on commit messages. Updated `pom.xml` to set the initial version to `0.0.1`, aligning with the new versioning strategy.