### PR TITLE
Add Allure Maven plugin and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build/
 
 ### Allure Report ###
 allure-results/
+.allure/

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,31 @@
                     </includes>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>2.12.0</version>
+                <configuration>
+                    <reportVersion>${allure.version}</reportVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>allure-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>allure-results</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Integrated the Allure Maven plugin into the build process to generate test reports. Updated `.gitignore` to exclude `.allure/` directory for better workspace cleanliness. These changes enhance test reporting and streamline project configuration.