### PR TITLE
    Add scheduled runs to API tests workflow

### DIFF
--- a/.github/workflows/run-api-tests.yaml
+++ b/.github/workflows/run-api-tests.yaml
@@ -7,6 +7,8 @@ on:
         description: 'Trigger API Tests'
         required: true
         default: 'yes'
+  schedule:
+    - cron: '00 12 * * 0,1,2,3,4,5,6'
 
 jobs:
   run-api-tests:


### PR DESCRIPTION
    Introduced a cron schedule to trigger API tests daily at 12:00 UTC. This ensures regular automated testing, improving reliability and early detection of issues.